### PR TITLE
Fix: Ensure correct target board is loaded when using Custom Board

### DIFF
--- a/protocol/z-wave/platform/SiliconLabs/AppsHw/inc/target_boards.h
+++ b/protocol/z-wave/platform/SiliconLabs/AppsHw/inc/target_boards.h
@@ -19,7 +19,10 @@
 /* Radio Board Definitions                                               */
 /*************************************************************************/
 
-#if defined(RADIO_BOARD_EFR32ZG13L)
+#if defined(RADIO_NO_BOARD)
+#include "radio_no_board.h"
+
+#elif defined(RADIO_BOARD_EFR32ZG13L)
 #include "radio_board_efr32zg13l.h"
 
 #elif defined(RADIO_BOARD_EFR32ZG13P32)
@@ -42,9 +45,6 @@
 
 #elif defined(RADIO_BOARD_BRD2705A)
 #include "radio_board_brd2705a.h"
-
-#elif defined(RADIO_NO_BOARD)
-#include "radio_no_board.h"
 
 #endif
 


### PR DESCRIPTION
When selecting "Custom Board" in the project wizard with the target device EFR32ZG23B020F512IM48, the template defines RADIO_BOARD_EFR32ZG23, which causes radio_board_efr32zg23 to be loaded in target_boards.

This fix ensures that when a project is started with "Custom Board," the radio_no_board configuration is correctly loaded instead.